### PR TITLE
Nile endpoint for authentication moved

### DIFF
--- a/python-flask-todo-list/app/__init__.py
+++ b/python-flask-todo-list/app/__init__.py
@@ -18,6 +18,9 @@ def create_app(test_config=None):
         # load the test config if passed in
         app.config.from_mapping(test_config)
 
+    print("Database: "+ app.config['DATABASE'])
+    print("Nile: "+ app.config['NILE'])
+
     # ensure the instance folder exists
     try:
         os.makedirs(app.instance_path)

--- a/python-flask-todo-list/app/nile.py
+++ b/python-flask-todo-list/app/nile.py
@@ -94,7 +94,7 @@ class NileClient(object):
             'email' : email,
             'password' : password
         }
-        data = self._send(method="POST", endpoint="/login", payload=payload)
+        data = self._send(method="POST", endpoint="/auth/login", payload=payload)
         token = data['token']
         try:
             user = jwt.decode(token, options={"verify_signature": False})


### PR DESCRIPTION
Note that this won't work against older Nile deployments (check X-NILE-VERSION header in the HTTP response, if you are on `6379124` then you'll need to ask for an updated Nile before updating the example. 