### PR TITLE
Update links in README to go to folder instead of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,6 @@ Each directory contains an individual example or demo. Check the README in each 
 
 | Example | Local | Docker | Description |
 |---------|-------|--------|-------------|
-| [Minimal Quickstart](https://github.com/TheNileDev/examples/blob/main/nodejs_quickstart/README.md) | Y |  N | A minimal example of using some of the core Nile APIs |
-| [Data Plane with Pulumi](data-plane/pulumi/README.md) | Y | N | This example demonstrates how to synchronize your data plane and control plane in real time with Nile events. |
-| [Python + Flask Todo List Webapp](https://github.com/TheNileDev/examples/blob/main/python-flask-todo-list/README.md) | Y | Y |  Taking a basic Todo List webapp written in Python and Flask and turning it to a PLG SaaS product with Nile APIs |
+| [Minimal Quickstart](nodejs_quickstart/) | Y |  N | A minimal example of using some of the core Nile APIs |
+| [Data Plane with Pulumi](data-plane/pulumi/) | Y | N | This example demonstrates how to synchronize your data plane and control plane in real time with Nile events. |
+| [Python + Flask Todo List Webapp](python-flask-todo-list/) | Y | Y |  Taking a basic Todo List webapp written in Python and Flask and turning it to a PLG SaaS product with Nile APIs |


### PR DESCRIPTION
- Improves UX: users don't have to click again to see the code
- Relative links easier to maintain