### PR TITLE
fix(data-plane/pulumi): Update Pulumi project name in code to match README.md

### DIFF
--- a/data-plane/pulumi/src/commands/reconcile/index.ts
+++ b/data-plane/pulumi/src/commands/reconcile/index.ts
@@ -46,7 +46,7 @@ export default class Reconcile extends Command {
 
     // pulumi setup
     this.deployment = await PulumiAwsDeployment.create(
-      'nile-examples',
+      'pulumi-clustify',
       pulumiS3
     );
     const stacks = await this.deployment.loadPulumiStacks();


### PR DESCRIPTION
This PR fixes the name of the Pulumi project.

A previous version of this demo used `nile-examples` as a project name, but it has since changed to `pulumi-clustify` in the README.

Without this PR, I validated the example still works, but it just pollutes Pulumi with an unnecessary empty project.