### PR TITLE
feature(data-plane/pulumi): automate creation of the control plane

### DIFF
--- a/data-plane/pulumi/.env.defaults
+++ b/data-plane/pulumi/.env.defaults
@@ -1,8 +1,15 @@
 NILE_URL=https://prod.thenile.dev:443
-NILE_WORKSPACE_NAME=<workspace name>
+
+NILE_WORKSPACE=<workspace name>
+
 NILE_DEVELOPER_EMAIL=<email>
 NILE_DEVELOPER_PASSWORD=<password>
+
+NILE_ORGANIZATION_NAME=<organization NAME>
+# NILE_ORGANIZATION_ID will not exist until the organization is created
 NILE_ORGANIZATION_ID=<organization ID>
+
 NILE_ENTITY_NAME=<entity name>
+
 #NILE_RECONCILER_STATUS=false
 #NILE_RECONCILER_REGION=us-west-2

--- a/data-plane/pulumi/.env.defaults
+++ b/data-plane/pulumi/.env.defaults
@@ -6,7 +6,5 @@ NILE_DEVELOPER_EMAIL=<enter email>
 NILE_DEVELOPER_PASSWORD=<enter password>
 
 NILE_ORGANIZATION_NAME=sac-norad
-# NILE_ORGANIZATION_ID will not exist until the organization is created
-NILE_ORGANIZATION_ID=<enter organization ID>
 
 NILE_ENTITY_NAME=SkyNet

--- a/data-plane/pulumi/.env.defaults
+++ b/data-plane/pulumi/.env.defaults
@@ -1,15 +1,12 @@
 NILE_URL=https://prod.thenile.dev:443
 
-NILE_WORKSPACE=<workspace name>
+NILE_WORKSPACE=clustify
 
-NILE_DEVELOPER_EMAIL=<email>
-NILE_DEVELOPER_PASSWORD=<password>
+NILE_DEVELOPER_EMAIL=<enter email>
+NILE_DEVELOPER_PASSWORD=<enter password>
 
-NILE_ORGANIZATION_NAME=<organization NAME>
+NILE_ORGANIZATION_NAME=sac-norad
 # NILE_ORGANIZATION_ID will not exist until the organization is created
-NILE_ORGANIZATION_ID=<organization ID>
+NILE_ORGANIZATION_ID=<enter organization ID>
 
-NILE_ENTITY_NAME=<entity name>
-
-#NILE_RECONCILER_STATUS=false
-#NILE_RECONCILER_REGION=us-west-2
+NILE_ENTITY_NAME=SkyNet

--- a/data-plane/pulumi/.env.defaults
+++ b/data-plane/pulumi/.env.defaults
@@ -1,6 +1,6 @@
 NILE_URL=https://prod.thenile.dev:443
 
-NILE_WORKSPACE=clustify
+NILE_WORKSPACE=<workspace>
 
 NILE_DEVELOPER_EMAIL=<enter email>
 NILE_DEVELOPER_PASSWORD=<enter password>

--- a/data-plane/pulumi/Dockerfile
+++ b/data-plane/pulumi/Dockerfile
@@ -25,4 +25,4 @@ WORKDIR /usr/src/reconciler
 RUN ["yarn", "install"]
 RUN ["yarn", "build"]
 
-ENTRYPOINT ["yarn", "start"]
+ENTRYPOINT ["yarn", "reconcile"]

--- a/data-plane/pulumi/README.md
+++ b/data-plane/pulumi/README.md
@@ -44,13 +44,13 @@ Copy the `.env.defaults` file to `.env`:
 cp .env.defaults .env
 ```
 
-And then set the values in this `.env` file to match the values you want to use in your control plane.
+Set the values in this `.env` file to match the values you want in your control plane.
 
 ## Configure the Control Plane ##
 
 There are a few ways to configure the control plane:
 
-- [Nile Admin Dashboard](#nile-admin-dashboard): use the UI to configure the control plane
+- [Nile Admin Dashboard](#nile-admin-dashboard): use the UI to manually configure the control plane
 - [Programmatically](#programmatically): use the provided script which leverages the SDK
 
 ### Nile Admin Dashboard

--- a/data-plane/pulumi/README.md
+++ b/data-plane/pulumi/README.md
@@ -99,12 +99,11 @@ For the values below, make sure they match what you set in the `.env` file.
 yarn install && yarn build
 ```
 
-2. Configure the control plane. This command will read from the `.env` file you defined earlier.
+2. Configure the control plane. This command will read from the `.env` file you defined earlier. The script is idempotent and instances will be created only once.
 
 ```bash
-yarn cp-configure
+yarn prereconcile
 ```
-
 
 ## Configure the Data Plane ##
 

--- a/data-plane/pulumi/README.md
+++ b/data-plane/pulumi/README.md
@@ -51,11 +51,11 @@ And then set the values in this `.env` file to match the values you want to use 
 There are a few ways to configure the control plane:
 
 - [Nile Admin Dashboard](#nile-admin-dashboard): use the UI to configure the control plane
-- Programmatically(#programmatically): Use the provided [cp-configure.ts](src/cp-configure.ts) script which leverages the SDK.
+- [Programmatically](#programmatically): use the provided script which leverages the SDK
 
 ### Nile Admin Dashboard
 
-> If you're not familiar with the terminology used below, be sure to read the
+> If you're not familiar with the terminology used below, read the
 > [Nile Quickstart](https://www.thenile.dev/docs/current/quick-start-ui).
 
 For the values below, make sure they match what you set in the `.env` file.
@@ -94,7 +94,7 @@ In the `.env` file, set `NILE_ORGANIZATION_NAME` and comment out `NILE_ORGANIZAT
 
 ### Programmatically
 
-1. In your `.env` file, be sure to set `NILE_ORGANIZATION_NAME` and comment out `NILE_ORGANIZATION_ID` (you won't know this yet).
+1. In your `.env` file, set `NILE_ORGANIZATION_NAME` and comment out `NILE_ORGANIZATION_ID` (you won't know this yet).
 
 2. Install and build the project
 
@@ -111,8 +111,8 @@ yarn cp-configure
 
 ## Configure the Data Plane ##
 
-> These instructions summarize how to [get started with Pulumi](https://www.pulumi.com/docs/get-started/aws/begin/)
-> on AWS. See their docs for a more complete setup.
+These instructions summarize how to get started with Pulumi on AWS.
+See the [Pulumi documentation](https://www.pulumi.com/docs/get-started/aws/begin/) for a more complete setup.
 
 1. Set up a new Pulumi project called `pulumi-clustify`:
 
@@ -148,11 +148,11 @@ pulumi up
 ## Run the reconciler ##
 
 Ensure that the values in your `.env` file match the values used in the setup of the control plane.
-Be sure to set `NILE_ORGANIZATION_ID` and comment out `NILE_ORGANIZATION_NAME`.
+Set `NILE_ORGANIZATION_ID` and comment out `NILE_ORGANIZATION_NAME`.
 Note that `NILE_ORGANIZATION_ID` is not visible in the [Nile Admin Dashboard](https://nad.thenile.dev/) yet, but can be obtained in the Nile Admin Dashboard from the URL when you select an org.
 For example, in the URL `https://nad.thenile.dev/clustify/organization/org_02qfJTCBve6bw0XlxC92CG`, the organization id is `org_02qfJTCBve6bw0XlxC92CG`.
 
-Next, there are several ways to run the reconciler, as described in the following sections:
+Next, there are several ways to run the reconciler, each described in the following sections:
 
 - [Using yarn](#using-yarn)
 - [Executable binary](#executable-binary)
@@ -181,7 +181,7 @@ yarn reconcile
 yarn install && yarn build
 ```
 
-2. Source the `.env` parameters into your shell.
+2. Source the `.env` parameters into your shell.  This step isn't necessary since you're passing in the Nile configuration values at the command line, but assuming you already went through the effort of configuring the `.env` file, may as well use it.
 
 ```bash
 source .env
@@ -200,7 +200,7 @@ source .env
 
 ### Docker
 
-1. Back up in the `data-plane/pulumi` directory, run the reconciler Docker image, taking note to validate the 3 input parameters required to connect to S3 and Pulumi:
+1. Back up in the `data-plane/pulumi` directory, run the reconciler Docker image. Ensure that you have valid values for the three input parameters required to connect to S3 (`AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`) and Pulumi (`PULUMI_ACCESS_TOKEN`):
 
 ```bash
 docker run --init --rm \
@@ -215,8 +215,8 @@ docker run --init --rm \
 
 The reconciler will immediately find the newly instantiated SkyNet instance in the Nile
 control plane and create a Pulumi stack that represents it, defined by the
-[`pulumis3` program](./src/commands/reconcile/lib/pulumi/pulumiS3.ts). This
-includes a new S3 bucket containing a static website and a bucket policy that
+[`pulumiS3.ts`](./src/commands/reconcile/lib/pulumi/pulumiS3.ts). Pulumi also
+created a new S3 bucket containing a static website and a bucket policy that
 allows public access.
 
 The reconciler will also log out the instance properties, including the 
@@ -239,12 +239,12 @@ Resources:
 Duration: 5s
 ```
 
-Pull up that `websiteUrl` in-browser and verify you see the provided `greeting`
+Pull up that `websiteUrl` in-browser and verify you see the provided "greeting"
 as well as all of the instance details.
 
 ## Add or Remove Instances ##
 
-In the [Nile Admin Dashboard](https://nad.thenile.dev/), add one or
-more SkyNet instances to the organization. This will trigger events that the
-command receives, and will synchronize accordingly. Deleting an instance in the
+While the reconciler is running, in the [Nile Admin Dashboard](https://nad.thenile.dev/), add one or
+more new SkyNet instances to the organization. This will trigger events that the
+reconciler receives and the data plane will synchronize accordingly. Deleting an instance in the
 control plane will result in destruction of the corresponding Pulumi stack.

--- a/data-plane/pulumi/README.md
+++ b/data-plane/pulumi/README.md
@@ -181,7 +181,7 @@ yarn reconcile
 yarn install && yarn build
 ```
 
-2. Source the `.env` parameters into your shell.  This step isn't necessary since you're passing in the Nile configuration values at the command line, but assuming you already went through the effort of configuring the `.env` file, may as well use it.
+2. Source the `.env` parameters into your shell.  This step isn't entirely necessary since in the next step you can pass in the Nile configuration parameter values at the command line, but assuming you already went through the effort of configuring the `.env` file, may as well use it.
 
 ```bash
 source .env
@@ -208,7 +208,7 @@ docker run --init --rm \
   -e AWS_ACCESS_KEY_ID=$(aws configure get aws_access_key_id) \
   -e AWS_SECRET_ACCESS_KEY=$(aws configure get aws_secret_access_key) \
   -e PULUMI_ACCESS_TOKEN=$PULUMI_ACCESS_TOKEN \
-  theniledev/reconciler:v0.1
+  theniledev/reconciler:v0.2
 ```
 
 ## Explanation

--- a/data-plane/pulumi/README.md
+++ b/data-plane/pulumi/README.md
@@ -59,7 +59,6 @@ There are a few ways to configure the control plane:
 > [Nile Quickstart](https://www.thenile.dev/docs/current/quick-start-ui).
 
 For the values below, make sure they match what you set in the `.env` file.
-In the `.env` file, set `NILE_ORGANIZATION_NAME` and comment out `NILE_ORGANIZATION_ID` (you won't know this yet).
 
 1. Login to the [Nile Admin Dashboard](https://nad.thenile.dev/).
 2. If there isn't one already, create a workspace named "clustify".
@@ -82,7 +81,7 @@ In the `.env` file, set `NILE_ORGANIZATION_NAME` and comment out `NILE_ORGANIZAT
 }
 ```
 
-4. Create an organization in the workspace named "sac-norad". Note that `NILE_ORGANIZATION_ID` is not visible in the dashboard yet, but can be obtained from the URL when you select the new organization that you just created. For example, in the URL `https://nad.thenile.dev/clustify/organization/org_02qfJTCBve6bw0XlxC92CG`, the organization id is `org_02qfJTCBve6bw0XlxC92CG`.
+4. Create an organization in the workspace named "sac-norad".
 5. Create a "SkyNet" instance in the organization, with a value that matches 
    the schema defined earlier:
 
@@ -94,15 +93,13 @@ In the `.env` file, set `NILE_ORGANIZATION_NAME` and comment out `NILE_ORGANIZAT
 
 ### Programmatically
 
-1. In your `.env` file, set `NILE_ORGANIZATION_NAME` and comment out `NILE_ORGANIZATION_ID` (you won't know this yet).
-
-2. Install and build the project
+1. Install and build the project
 
 ```bash
 yarn install && yarn build
 ```
 
-3. Configure the control plane. This command will read from the `.env` file you defined earlier.
+2. Configure the control plane. This command will read from the `.env` file you defined earlier.
 
 ```bash
 yarn cp-configure

--- a/data-plane/pulumi/README.md
+++ b/data-plane/pulumi/README.md
@@ -4,6 +4,7 @@
 
 * [Overview](#overview)
 * [Prerequisites](#prerequisites)
+* [Setup](#setup)
 * [Configure the Control Plane](#configure-the-control-plane)
 * [Configure the Data Plane](#configure-the-data-plane)
 * [Run the reconciler](#run-the-reconciler)
@@ -33,9 +34,10 @@ This example assumes you have:
 * [The Pulumi CLI installed](https://www.pulumi.com/docs/reference/cli/)
 * A Nile developer account using an email address and password
 
-## Configure the Control Plane ##
+## Setup
 
-For future steps, it will be helpful to have a local Nile configuration file.
+For future steps, it will be helpful to have a local file with your Nile configuration.
+For that purpose, in this example, you will create a `.env` file with environment variables.
 Copy the `.env.defaults` file to `.env`:
 
 ```bash
@@ -43,6 +45,8 @@ cp .env.defaults .env
 ```
 
 And then set the values in this `.env` file to match the values you want to use in your control plane.
+
+## Configure the Control Plane ##
 
 There are a few ways to configure the control plane:
 
@@ -90,14 +94,7 @@ In the `.env` file, set `NILE_ORGANIZATION_NAME` and comment out `NILE_ORGANIZAT
 
 ### Programmatically
 
-1. Copy the `.env.defaults` file to `.env`:
-
-```bash
-cp .env.defaults .env
-```
-
-And then set the values in this `.env` file to match the values used in the setup of the control plane.
-Be sure to set `NILE_ORGANIZATION_NAME` and comment out `NILE_ORGANIZATION_ID` (you won't know this yet).
+1. In your `.env` file, be sure to set `NILE_ORGANIZATION_NAME` and comment out `NILE_ORGANIZATION_ID` (you won't know this yet).
 
 2. Install and build the project
 
@@ -105,7 +102,7 @@ Be sure to set `NILE_ORGANIZATION_NAME` and comment out `NILE_ORGANIZATION_ID` (
 yarn install && yarn build
 ```
 
-3. Configure the control plane. This command will read from the `.env` file you set earlier.
+3. Configure the control plane. This command will read from the `.env` file you defined earlier.
 
 ```bash
 yarn cp-configure
@@ -150,13 +147,7 @@ pulumi up
 
 ## Run the reconciler ##
 
-Back up in the `data-plane/pulumi` directory, first copy the `.env.defaults` file to `.env`:
-
-```bash
-cp .env.defaults .env
-```
-
-And then set the values in this `.env` file to match the values used in the setup of the control plane.
+Ensure that the values in your `.env` file match the values used in the setup of the control plane.
 Be sure to set `NILE_ORGANIZATION_ID` and comment out `NILE_ORGANIZATION_NAME`.
 Note that `NILE_ORGANIZATION_ID` is not visible in the [Nile Admin Dashboard](https://nad.thenile.dev/) yet, but can be obtained in the Nile Admin Dashboard from the URL when you select an org.
 For example, in the URL `https://nad.thenile.dev/clustify/organization/org_02qfJTCBve6bw0XlxC92CG`, the organization id is `org_02qfJTCBve6bw0XlxC92CG`.
@@ -176,7 +167,7 @@ Next, there are several ways to run the reconciler, as described in the followin
 yarn install && yarn build
 ```
 
-2. Run the reconciler. This command will read from the `.env` file you set earlier.
+2. Run the reconciler. This command will read from the `.env` file you defined earlier.
 
 ```bash
 yarn reconcile

--- a/data-plane/pulumi/README.md
+++ b/data-plane/pulumi/README.md
@@ -148,16 +148,12 @@ pulumi up
 ## Run the reconciler ##
 
 Ensure that the values in your `.env` file match the values used in the setup of the control plane.
-Set `NILE_ORGANIZATION_ID` and comment out `NILE_ORGANIZATION_NAME`.
-Note that `NILE_ORGANIZATION_ID` is not visible in the [Nile Admin Dashboard](https://nad.thenile.dev/) yet, but can be obtained in the Nile Admin Dashboard from the URL when you select an org.
-For example, in the URL `https://nad.thenile.dev/clustify/organization/org_02qfJTCBve6bw0XlxC92CG`, the organization id is `org_02qfJTCBve6bw0XlxC92CG`.
 
 Next, there are several ways to run the reconciler, each described in the following sections:
 
 - [Using yarn](#using-yarn)
 - [Executable binary](#executable-binary)
 - [Docker](#docker) 
-
 
 ### Using `yarn`
 
@@ -193,7 +189,7 @@ source .env
  ./bin/dev reconcile --basePath $NILE_URL \
  --workspace $NILE_WORKSPACE \
  --entity $NILE_ENTITY_NAME \
- --organization $NILE_ORGANIZATION_ID \
+ --organizationName $NILE_ORGANIZATION_NAME \
  --email $NILE_DEVELOPER_EMAIL \
  --password $NILE_DEVELOPER_PASSWORD
  ```

--- a/data-plane/pulumi/README.md
+++ b/data-plane/pulumi/README.md
@@ -35,8 +35,27 @@ This example assumes you have:
 
 ## Configure the Control Plane ##
 
+For future steps, it will be helpful to have a local Nile configuration file.
+Copy the `.env.defaults` file to `.env`:
+
+```bash
+cp .env.defaults .env
+```
+
+And then set the values in this `.env` file to match the values you want to use in your control plane.
+
+There are a few ways to configure the control plane:
+
+- [Nile Admin Dashboard](#nile-admin-dashboard): use the UI to configure the control plane
+- Programmatically(#programmatically): Use the provided [cp-configure.ts](src/cp-configure.ts) script which leverages the SDK.
+
+### Nile Admin Dashboard
+
 > If you're not familiar with the terminology used below, be sure to read the
 > [Nile Quickstart](https://www.thenile.dev/docs/current/quick-start-ui).
+
+For the values below, make sure they match what you set in the `.env` file.
+In the `.env` file, set `NILE_ORGANIZATION_NAME` and comment out `NILE_ORGANIZATION_ID` (you won't know this yet).
 
 1. Login to the [Nile Admin Dashboard](https://nad.thenile.dev/).
 2. If there isn't one already, create a workspace named "clustify".
@@ -59,7 +78,7 @@ This example assumes you have:
 }
 ```
 
-4. Create an organization in the workspace named "sac-norad".
+4. Create an organization in the workspace named "sac-norad". Note that `NILE_ORGANIZATION_ID` is not visible in the dashboard yet, but can be obtained from the URL when you select the new organization that you just created. For example, in the URL `https://nad.thenile.dev/clustify/organization/org_02qfJTCBve6bw0XlxC92CG`, the organization id is `org_02qfJTCBve6bw0XlxC92CG`.
 5. Create a "SkyNet" instance in the organization, with a value that matches 
    the schema defined earlier:
 
@@ -68,6 +87,30 @@ This example assumes you have:
   "greeting": "Come with me if you want to live."
 }
 ```
+
+### Programmatically
+
+1. Copy the `.env.defaults` file to `.env`:
+
+```bash
+cp .env.defaults .env
+```
+
+And then set the values in this `.env` file to match the values used in the setup of the control plane.
+Be sure to set `NILE_ORGANIZATION_NAME` and comment out `NILE_ORGANIZATION_ID` (you won't know this yet).
+
+2. Install and build the project
+
+```bash
+yarn install && yarn build
+```
+
+3. Configure the control plane. This command will read from the `.env` file you set earlier.
+
+```bash
+yarn cp-configure
+```
+
 
 ## Configure the Data Plane ##
 
@@ -107,17 +150,23 @@ pulumi up
 
 ## Run the reconciler ##
 
-There are several ways to run the reconciler, as described in the following sections.
-
-For any of these options, back up in the `data-plane/pulumi` directory, first copy the `.env.defaults` file to `.env`:
+Back up in the `data-plane/pulumi` directory, first copy the `.env.defaults` file to `.env`:
 
 ```bash
 cp .env.defaults .env
 ```
 
 And then set the values in this `.env` file to match the values used in the setup of the control plane.
-One of the values required is `NILE_ORGANIZATION_ID` which is not visible in the NAD yet, but can be obtained in NAD from the URL when you select an org.
+Be sure to set `NILE_ORGANIZATION_ID` and comment out `NILE_ORGANIZATION_NAME`.
+Note that `NILE_ORGANIZATION_ID` is not visible in the [Nile Admin Dashboard](https://nad.thenile.dev/) yet, but can be obtained in the Nile Admin Dashboard from the URL when you select an org.
 For example, in the URL `https://nad.thenile.dev/clustify/organization/org_02qfJTCBve6bw0XlxC92CG`, the organization id is `org_02qfJTCBve6bw0XlxC92CG`.
+
+Next, there are several ways to run the reconciler, as described in the following sections:
+
+- [Using yarn](#using-yarn)
+- [Executable binary](#executable-binary)
+- [Docker](#docker) 
+
 
 ### Using `yarn`
 
@@ -127,10 +176,10 @@ For example, in the URL `https://nad.thenile.dev/clustify/organization/org_02qfJ
 yarn install && yarn build
 ```
 
-2. Run the reconciler:
+2. Run the reconciler. This command will read from the `.env` file you set earlier.
 
 ```bash
-yarn start
+yarn reconcile
 ```
 
 ### Executable binary
@@ -151,7 +200,7 @@ source .env
 
 ```bash
  ./bin/dev reconcile --basePath $NILE_URL \
- --workspace $NILE_WORKSPACE_NAME \
+ --workspace $NILE_WORKSPACE \
  --entity $NILE_ENTITY_NAME \
  --organization $NILE_ORGANIZATION_ID \
  --email $NILE_DEVELOPER_EMAIL \

--- a/data-plane/pulumi/package.json
+++ b/data-plane/pulumi/package.json
@@ -63,7 +63,8 @@
     "postpack": "shx rm -f oclif.manifest.json",
     "posttest": "yarn lint",
     "prepack": "yarn build && oclif manifest && oclif readme",
-    "start": "yarn build && ts-node src/reconciler.ts",
+    "cp-configure": "yarn build && ts-node src/cp-configure.ts",
+    "reconcile": "yarn build && ts-node src/reconciler.ts",
     "test": "mocha --forbid-only \"test/**/*.test.ts\"",
     "version": "oclif readme && git add README.md"
   },

--- a/data-plane/pulumi/package.json
+++ b/data-plane/pulumi/package.json
@@ -63,7 +63,7 @@
     "postpack": "shx rm -f oclif.manifest.json",
     "posttest": "yarn lint",
     "prepack": "yarn build && oclif manifest && oclif readme",
-    "cp-configure": "yarn build && ts-node src/cp-configure.ts",
+    "prereconcile": "yarn build && ts-node src/cp-configure.ts",
     "reconcile": "yarn build && ts-node src/reconciler.ts",
     "test": "mocha --forbid-only \"test/**/*.test.ts\"",
     "version": "oclif readme && git add README.md"

--- a/data-plane/pulumi/src/commands/reconcile/flagDefaults.ts
+++ b/data-plane/pulumi/src/commands/reconcile/flagDefaults.ts
@@ -20,9 +20,6 @@ export const flagDefaults = {
   authToken: Flags.string({
     description: 'developer access token. If used, this overrides the email/password flags.'
   }),
-  organization: Flags.string({
-    description: 'an organization ID in your Nile workspace. If used, this overrides the organizationName flag.',
-  }),
   organizationName: Flags.string({
     description: 'an organization name in your Nile workspace',
   }),

--- a/data-plane/pulumi/src/commands/reconcile/flagDefaults.ts
+++ b/data-plane/pulumi/src/commands/reconcile/flagDefaults.ts
@@ -21,7 +21,10 @@ export const flagDefaults = {
     description: 'developer access token. If used, this overrides the email/password flags.'
   }),
   organization: Flags.string({
-    description: 'an organization in your Nile workspace',
+    description: 'an organization ID in your Nile workspace. If used, this overrides the organizationName flag.',
+  }),
+  organizationName: Flags.string({
+    description: 'an organization name in your Nile workspace',
   }),
   entity: Flags.string({
     description: 'an entity type in your Nile workspace',

--- a/data-plane/pulumi/src/commands/reconcile/index.ts
+++ b/data-plane/pulumi/src/commands/reconcile/index.ts
@@ -35,12 +35,12 @@ export default class Reconcile extends Command {
     }).connect(authToken ?? { email, password });
 
     if (!organizationName) {
-      console.error ("Must pass in organizationName");
+      console.error ("Error: must pass in organizationName");
       process.exit(1);
     }
     let orgID = await this.getOrgIDFromOrgName(organizationName!);
     if (!orgID) {
-      console.error ("Cannot determine the ID of the organization from the provided name :" + organizationName)
+      console.error ("Error: cannot determine the ID of the organization from the provided name :" + organizationName)
       process.exit(1);
     } else {
       console.log("Organization with name " + organizationName + " exists with id " + orgID)

--- a/data-plane/pulumi/src/commands/reconcile/index.ts
+++ b/data-plane/pulumi/src/commands/reconcile/index.ts
@@ -19,7 +19,6 @@ export default class Reconcile extends Command {
     const { flags } = await this.parse(Reconcile);
     const {
       status,
-      organization,
       organizationName,
       entity,
       basePath,
@@ -35,16 +34,13 @@ export default class Reconcile extends Command {
       workspace,
     }).connect(authToken ?? { email, password });
 
-    // Get orgID either as:
-    // -- input parameter of ID (organization)
-    // -- lookup from input parameter of name (organizationName)
-    if (!organization && !organizationName) {
-      console.error ("Must pass in either organization or organizationName");
+    if (!organizationName) {
+      console.error ("Must pass in organizationName");
       process.exit(1);
     }
-    let orgID = organization || await this.getOrgIDFromOrgName(organizationName!);
+    let orgID = await this.getOrgIDFromOrgName(organizationName!);
     if (!orgID) {
-      console.error ("Cannot determine the ID of the organization.  Check input parameters.")
+      console.error ("Cannot determine the ID of the organization from the provided name :" + organizationName)
       process.exit(1);
     }
 

--- a/data-plane/pulumi/src/commands/reconcile/index.ts
+++ b/data-plane/pulumi/src/commands/reconcile/index.ts
@@ -42,6 +42,8 @@ export default class Reconcile extends Command {
     if (!orgID) {
       console.error ("Cannot determine the ID of the organization from the provided name :" + organizationName)
       process.exit(1);
+    } else {
+      console.log("Organization with name " + organizationName + " exists with id " + orgID)
     }
 
     // load instances
@@ -176,10 +178,8 @@ export default class Reconcile extends Command {
     var myOrgs = await this.nile.organizations.listOrganizations()
     var maybeOrg = myOrgs.find( org => org.name == orgName)
     if (maybeOrg) {
-      console.log("Organization with name " + orgName + " exists with id " + maybeOrg.id)
       return maybeOrg.id
     } else {
-      console.log("Organization with name " + orgName + " does not exist")
       return null
     }
   }

--- a/data-plane/pulumi/src/cp-configure.ts
+++ b/data-plane/pulumi/src/cp-configure.ts
@@ -88,6 +88,14 @@ async function setup_control_plane() {
       await nile.workspaces.createWorkspace({
         createWorkspaceRequest: { name: NILE_WORKSPACE },
       }).then( (ws) => { if (ws != null)  console.log('\x1b[32m%s\x1b[0m', "\u2713", "Created workspace: " + ws.name)})
+        .catch((error:any) => {
+          if (error.message == "workspace already exists") {
+            console.error(`Workspace ${NILE_WORKSPACE} already exists`)
+            process.exit(1);
+          } else {
+            console.error(error)
+          }
+        })
   }
 
   // Check if entity exists, create if not

--- a/data-plane/pulumi/src/cp-configure.ts
+++ b/data-plane/pulumi/src/cp-configure.ts
@@ -90,7 +90,7 @@ async function setup_control_plane() {
       }).then( (ws) => { if (ws != null)  console.log('\x1b[32m%s\x1b[0m', "\u2713", "Created workspace: " + ws.name)})
         .catch((error:any) => {
           if (error.message == "workspace already exists") {
-            console.error(`Workspace ${NILE_WORKSPACE} already exists`)
+            console.error(`Workspace ${NILE_WORKSPACE} already exists (workspace names are globally unique)`)
             process.exit(1);
           } else {
             console.error(error)

--- a/data-plane/pulumi/src/cp-configure.ts
+++ b/data-plane/pulumi/src/cp-configure.ts
@@ -72,7 +72,7 @@ async function setup_control_plane() {
       password: NILE_DEVELOPER_PASSWORD,
     },
   }).catch((error:any) => {
-    console.error(`Failed to login to Nile as developer ${NILE_DEVELOPER_EMAIL}: ` + error.message);
+    console.error(`Error: Failed to login to Nile as developer ${NILE_DEVELOPER_EMAIL}: ` + error.message);
     process.exit(1);
   });
 
@@ -90,7 +90,7 @@ async function setup_control_plane() {
       }).then( (ws) => { if (ws != null)  console.log('\x1b[32m%s\x1b[0m', "\u2713", "Created workspace: " + ws.name)})
         .catch((error:any) => {
           if (error.message == "workspace already exists") {
-            console.error(`Workspace ${NILE_WORKSPACE} already exists (workspace names are globally unique)`)
+            console.error(`Error: workspace ${NILE_WORKSPACE} already exists (workspace names are globally unique)`)
             process.exit(1);
           } else {
             console.error(error)

--- a/data-plane/pulumi/src/cp-configure.ts
+++ b/data-plane/pulumi/src/cp-configure.ts
@@ -131,15 +131,25 @@ async function setup_control_plane() {
     }).catch((error:any) => console.error(error.message));
   }
 
-  // Create an instance of the service in the data plane
-  const identifier = Math.floor(Math.random() * 100000)
-  await nile.entities.createInstance({
-    org : tenant_id,
-    type : entityDefinition.name,
-    body : {
-      greeting : `Come with me if you want to live: ${identifier}`
-    }
-  }).then((entity_instance) => console.log ('\x1b[32m%s\x1b[0m', "\u2713", "Created entity instances: " + JSON.stringify(entity_instance, null, 2)))
+  // Check if entity instance already exists, create if not
+  var myInstances = await nile.entities.listInstances({
+        org: tenant_id,
+        type: NILE_ENTITY_NAME,
+      })
+  var maybeInstance = myInstances.find( instance => instance.type == NILE_ENTITY_NAME)
+  if (maybeInstance) {
+    console.log("Entity instance " + NILE_ENTITY_NAME + " exists with id " + maybeInstance.id)
+  } else {
+    console.log(myInstances);
+    const identifier = Math.floor(Math.random() * 100000)
+    await nile.entities.createInstance({
+      org : tenant_id,
+      type : entityDefinition.name,
+      body : {
+        greeting : `Come with me if you want to live: ${identifier}`
+      }
+    }).then((entity_instance) => console.log ('\x1b[32m%s\x1b[0m', "\u2713", "Created entity instances: " + JSON.stringify(entity_instance, null, 2)))
+  }
 
   // List instances of the service
   await nile.entities.listInstances({

--- a/data-plane/pulumi/src/cp-configure.ts
+++ b/data-plane/pulumi/src/cp-configure.ts
@@ -1,0 +1,147 @@
+import Nile, { CreateEntityRequest, Entity, Organization} from "@theniledev/js";
+import { CreateEntityOperationRequest } from "@theniledev/js/dist/generated/openapi/src";
+
+import Reconcile from "./commands/reconcile/index"
+
+import * as dotenv from "dotenv";
+
+dotenv.config({ override: true })
+
+let envParams = [
+  "NILE_URL",
+  "NILE_WORKSPACE",
+  "NILE_DEVELOPER_EMAIL",
+  "NILE_DEVELOPER_PASSWORD",
+  "NILE_ORGANIZATION_NAME",
+  "NILE_ENTITY_NAME",
+]
+envParams.forEach( (key: string) => {
+  if (!process.env[key]) {
+    console.error(`Error: missing environment variable ${ key }. See .env.defaults for more info and copy it to .env with your values`);
+    process.exit(1);
+  }
+});
+
+const NILE_URL = process.env.NILE_URL!;
+const NILE_WORKSPACE = process.env.NILE_WORKSPACE!;
+const NILE_DEVELOPER_EMAIL = process.env.NILE_DEVELOPER_EMAIL!;
+const NILE_DEVELOPER_PASSWORD = process.env.NILE_DEVELOPER_PASSWORD!;
+const NILE_ORGANIZATION_NAME = process.env.NILE_ORGANIZATION_NAME!;
+const NILE_ENTITY_NAME = process.env.NILE_ENTITY_NAME!;
+
+const nile = Nile({
+  basePath: NILE_URL,
+  workspace: NILE_WORKSPACE,
+});
+
+// Schema for the entity that defines the service in the data plane
+const entityDefinition: CreateEntityRequest = {
+    "name": NILE_ENTITY_NAME,
+    "schema": {
+      "type": "object",
+      "properties": {
+        "greeting": { "type": "string" }
+      },
+      "required": ["greeting"]
+    }
+};
+
+// Setup the Control Plane
+async function setup_control_plane() {
+
+  console.log(`\nLogging into Nile at ${NILE_URL}, workspace ${NILE_WORKSPACE}, as developer ${NILE_DEVELOPER_EMAIL}`)
+
+  // Signup developer
+  await nile.developers.createDeveloper({
+    createUserRequest : {
+      email : NILE_DEVELOPER_EMAIL,
+      password : NILE_DEVELOPER_PASSWORD,
+    }
+  }).catch((error:any) => {
+    if (error.message == "user already exists") {
+      console.log(`Developer ${NILE_DEVELOPER_EMAIL} already exists`)
+    } else {
+      console.error(error)
+    }
+  })
+
+  // Login developer
+  await nile.developers.loginDeveloper({
+    loginInfo: {
+      email: NILE_DEVELOPER_EMAIL,
+      password: NILE_DEVELOPER_PASSWORD,
+    },
+  }).catch((error:any) => {
+    console.error(`Failed to login to Nile as developer ${NILE_DEVELOPER_EMAIL}: ` + error.message);
+    process.exit(1);
+  });
+
+  // Get the JWT token
+  nile.authToken = nile.developers.authToken;
+  console.log('\x1b[32m%s\x1b[0m', "\u2713", `Logged into Nile as developer ${NILE_DEVELOPER_EMAIL}!\nToken: ` + nile.authToken)
+
+  // Check if workspace exists, create if not
+  var myWorkspaces = await nile.workspaces.listWorkspaces()
+  if ( myWorkspaces.find( ws => ws.name==NILE_WORKSPACE) != null) {
+         console.log("Workspace " + NILE_WORKSPACE + " exists");
+  } else {
+      await nile.workspaces.createWorkspace({
+        createWorkspaceRequest: { name: NILE_WORKSPACE },
+      }).then( (ws) => { if (ws != null)  console.log('\x1b[32m%s\x1b[0m', "\u2713", "Created workspace: " + ws.name)})
+  }
+
+  // Check if entity exists, create if not
+  var myEntities =  await nile.entities.listEntities()
+  if (myEntities.find( ws => ws.name==entityDefinition.name)) { 
+      console.log("Entity " + entityDefinition.name + " exists");
+  } else {
+      await nile.entities.createEntity({
+        createEntityRequest: entityDefinition
+      }).then((data) => 
+      {
+        console.log('\x1b[32m%s\x1b[0m', "\u2713", 'Created entity: ' + JSON.stringify(data, null, 2));
+      }).catch((error:any) => console.error(error.message)); 
+  }
+
+  // Check if organization exists, create if not
+  var myOrgs = await nile.organizations.listOrganizations()
+  var maybeTenant = myOrgs.find( org => org.name == NILE_ORGANIZATION_NAME)
+  var tenant_id! : string
+
+  if (maybeTenant) {
+    console.log("Org " + NILE_ORGANIZATION_NAME + " exists with id " + maybeTenant.id)
+    tenant_id = maybeTenant.id
+  } else {
+    await nile.organizations.createOrganization({"createOrganizationRequest" :
+    {
+      name : NILE_ORGANIZATION_NAME,
+    }}).then ( (org) => {
+      if (org != null) {
+        console.log('\x1b[32m%s\x1b[0m', "\u2713", "Created Tenant: " + org.name)
+        tenant_id = org.id
+      }
+    }).catch((error:any) => console.error(error.message));
+  }
+
+  // Create an instance of the service in the data plane
+  const identifier = Math.floor(Math.random() * 100000)
+  await nile.entities.createInstance({
+    org : tenant_id,
+    type : entityDefinition.name,
+    body : {
+      greeting : `Come with me if you want to live: ${identifier}`
+    }
+  }).then((entity_instance) => console.log ('\x1b[32m%s\x1b[0m', "\u2713", "Created entity instances: " + JSON.stringify(entity_instance, null, 2)))
+
+  // List instances of the service
+  await nile.entities.listInstances({
+    org: tenant_id,
+    type: entityDefinition.name
+  }).then((entity_instances) => {
+    console.log("The following entity instances exist:")
+    console.log(entity_instances)
+  })
+  
+}
+
+setup_control_plane()

--- a/data-plane/pulumi/src/reconciler.ts
+++ b/data-plane/pulumi/src/reconciler.ts
@@ -9,7 +9,7 @@ let envParams = [
   "NILE_WORKSPACE",
   "NILE_DEVELOPER_EMAIL",
   "NILE_DEVELOPER_PASSWORD",
-  "NILE_ORGANIZATION_ID",
+  "NILE_ORGANIZATION_NAME",
   "NILE_ENTITY_NAME",
 ]
 envParams.forEach( (key: string) => {
@@ -23,7 +23,7 @@ const basePath = process.env.NILE_URL!;
 const workspace = process.env.NILE_WORKSPACE!;
 const email = process.env.NILE_DEVELOPER_EMAIL!;
 const password = process.env.NILE_DEVELOPER_PASSWORD!;
-const organization = process.env.NILE_ORGANIZATION_ID!;
+const organizationName = process.env.NILE_ORGANIZATION_NAME!;
 const entity = process.env.NILE_ENTITY_NAME!;
 
 async function run() {
@@ -33,7 +33,7 @@ async function run() {
     '--workspace', workspace,
     '--email', email,
     '--password', password,
-    '--organization', organization,
+    '--organizationName', organizationName,
     '--entity', entity
   ])
 

--- a/data-plane/pulumi/src/reconciler.ts
+++ b/data-plane/pulumi/src/reconciler.ts
@@ -6,7 +6,7 @@ dotenv.config({ override: true })
 
 let envParams = [
   "NILE_URL",
-  "NILE_WORKSPACE_NAME",
+  "NILE_WORKSPACE",
   "NILE_DEVELOPER_EMAIL",
   "NILE_DEVELOPER_PASSWORD",
   "NILE_ORGANIZATION_ID",
@@ -20,7 +20,7 @@ envParams.forEach( (key: string) => {
 });
 
 const basePath = process.env.NILE_URL!;
-const workspace = process.env.NILE_WORKSPACE_NAME!;
+const workspace = process.env.NILE_WORKSPACE!;
 const email = process.env.NILE_DEVELOPER_EMAIL!;
 const password = process.env.NILE_DEVELOPER_PASSWORD!;
 const organization = process.env.NILE_ORGANIZATION_ID!;


### PR DESCRIPTION
New:

- Automates the steps in the README that setup the control plane (run with `yarn cp-reconcile`).  It is idempotent and can be run multiple times, and does not result in new entity instances if the specified type already exists
- Obviates the need to hunt down the org ID, instead allowing user to pass in org name

Additional changes:

- In Reconciler: forced to pass in org name instead of the org ID
- Reconciler: renames `yarn start` to `yarn reconcile`
- Modifies `data-plane/pulumi/.env.defaults` (expected parameter names)
- Uses v0.2 reconciler Docker image
