### PR TITLE
feat(webapp): add some kind of policies

### DIFF
--- a/webapp/components/CreateOrg/index.tsx
+++ b/webapp/components/CreateOrg/index.tsx
@@ -1,14 +1,14 @@
 import React from 'react';
 import { useRouter } from 'next/router';
 import { Alert, Stack } from '@mui/material';
-import { CreateOrganizationRequest } from '@theniledev/js';
+import { CreateOrganizationRequest, Organization } from '@theniledev/js';
 import { Queries, useMutation, useNile } from '@theniledev/react';
 import { useForm } from 'react-hook-form';
 import { TextField, Button, Typography, Box } from '@mui/joy';
 
 import NavBar from '../NavBar';
 import getConfig from 'next/config';
-
+import { useAddOrgPolicy } from './policies';
 
 export default function AddOrgForm() {
   const nile = useNile();
@@ -17,19 +17,24 @@ export default function AddOrgForm() {
   const [error, setError] = React.useState<null | string>();
   const { publicRuntimeConfig } = getConfig();
   const { NILE_ENTITY_NAME } = publicRuntimeConfig;
+  const addOrgPolicy = useAddOrgPolicy();
+
+  const handleMutationSuccess = React.useCallback(async (data: Organization) => {
+      if (!NILE_ENTITY_NAME) {
+        alert('no entity type has been entered.')
+      } else {
+        await addOrgPolicy(data.id);
+        router.push(`/entities/${NILE_ENTITY_NAME}`);
+      }
+  }, [NILE_ENTITY_NAME, addOrgPolicy, router])
+
   const mutation = useMutation(
     (data: CreateOrganizationRequest) =>
       nile.organizations.createOrganization({
         createOrganizationRequest: data,
       }),
     {
-      onSuccess: (data) => {
-        if (!NILE_ENTITY_NAME) {
-          alert('no entity type has been entered.')
-        }else {
-          router.push(`/entities/${NILE_ENTITY_NAME}`);
-        }
-      },
+      onSuccess: handleMutationSuccess,
       onError: (e: Error) => {
         if (typeof e.message === 'string') {
           setError(e.message);
@@ -59,7 +64,7 @@ export default function AddOrgForm() {
         >
           <TextField
             {...register('name')}
-            sx={{maxWidth: '30rem'}}
+            sx={{ maxWidth: '30rem' }}
             id="name"
             name="name"
             label="Name"

--- a/webapp/components/CreateOrg/policies.ts
+++ b/webapp/components/CreateOrg/policies.ts
@@ -1,0 +1,101 @@
+import { CreatePolicyRequest, Action, User } from "@theniledev/js";
+import { useMutation, useNile } from "@theniledev/react";
+import getConfig from "next/config";
+
+const { publicRuntimeConfig } = getConfig();
+const { NILE_ENTITY_NAME } = publicRuntimeConfig;
+
+export const ADMIN = 'admin';
+export const READ_WRITE = 'RW';
+export const READ_ONLY = 'RO';
+
+export const checkAccess = (user: void | User) => {
+  const { role } = (user?.metadata ?? {}) as Record<string, any>;
+  return role === ADMIN || role === READ_WRITE
+}
+
+const AdminRole: CreatePolicyRequest = {
+  subject: {
+    metadata: {
+      role: ADMIN 
+    }
+  },
+  resource: {
+    type: NILE_ENTITY_NAME
+  },
+  actions: new Set([Action.Read, Action.Write]),
+};
+
+const ReadOnly: CreatePolicyRequest = {
+  subject: {
+    metadata: {
+      role: READ_ONLY 
+    }
+  },
+  resource: {
+    type: NILE_ENTITY_NAME
+  },
+  actions: new Set([Action.Read]),
+}
+
+const ReadWrite: CreatePolicyRequest = {
+  subject: {
+    metadata: {
+      role: READ_WRITE
+    }
+  },
+  resource: {
+    type: NILE_ENTITY_NAME
+  },
+  actions: new Set([Action.Read, Action.Write]),
+}
+
+const Denied: CreatePolicyRequest = {
+  subject: {},
+  resource: {
+    type: NILE_ENTITY_NAME
+  },
+  actions: new Set([Action.Deny]),
+}
+
+export function useAddOrgPolicy() {
+  const nile = useNile();
+
+  const adminRole = useMutation((org: string) => 
+    nile.access.createPolicy({
+      org,
+      createPolicyRequest: AdminRole
+    })
+  );
+
+  const readOnly = useMutation((org: string) => 
+    nile.access.createPolicy({
+      org,
+      createPolicyRequest: ReadOnly
+    })
+  );
+  
+  const readWrite = useMutation((org: string) => 
+    nile.access.createPolicy({
+      org,
+      createPolicyRequest: ReadWrite 
+    })
+  );
+
+  const denied = useMutation((org: string) => 
+    nile.access.createPolicy({
+      org,
+      createPolicyRequest: Denied
+    })
+  );
+  
+  return async(orgId: string) => {
+    const requests = await Promise.all([
+      adminRole.mutate(orgId),
+      readOnly.mutate(orgId),
+      readWrite.mutate(orgId),
+      denied.mutate(orgId)
+    ]);
+    console.log(requests);
+  }
+}

--- a/webapp/components/EntityTable/EntityTable.tsx
+++ b/webapp/components/EntityTable/EntityTable.tsx
@@ -8,6 +8,7 @@ import getConfig from 'next/config'
 import NavBar from '../NavBar';
 import { CreateInstance } from './CreateInstance';
 import { useFirstOrg } from './hooks';
+import { checkAccess } from '../CreateOrg/policies';
 
 
 export default function ClustersTable(){
@@ -15,6 +16,8 @@ export default function ClustersTable(){
   const [isLoading, user, org, unauthorized] = useFirstOrg();
   const { publicRuntimeConfig } = getConfig();
   const { NILE_ENTITY_NAME } = publicRuntimeConfig;
+
+  const hasAccess = React.useMemo(() => checkAccess(user), [user]);
 
   // just a simple refresh for now.
   React.useEffect(() => {
@@ -46,7 +49,13 @@ export default function ClustersTable(){
                 justifyContent: 'flex-end'
               }}
             >
-              <CreateInstance key="create-instance" org={org.id} setReRender={() => setReRender(true)}/>
+              { hasAccess && (
+                <CreateInstance 
+                  key="create-instance" 
+                  org={org.id} 
+                  setReRender={() => setReRender(true)}
+                />
+              )}
             </Box>
           </Stack>
           {reRender ? null : (


### PR DESCRIPTION
### Description

pretty broken, but unsure what to do next. I think I have to add a user management screen so you can assign a role to a user. 

_What behavior does this PR change, and why?_

_Note any breaking changes_

### Checklist before merge

<!-- - [ ] Manually validate examples in prod -->
<!-- - [ ] Workflow in GitHub Actions passes -->
<!-- - [ ] Update relevant READMEs -->
<!-- - [ ] Spell check (e.g. using `aspell`) -->
<!-- - [ ] Ensure `Squash and merge` is checked -->
<!-- - [ ] Update GH workflow -->
<!-- - [ ] Update PR template -->

### Submitter Validation

_Describe the validation already done, or needs to be done, by the PR submitter._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] quickstart -->
<!-- - [ ] multi-tenancy -->
<!-- - [ ] data-plane/pulumi -->
<!-- - [ ] authz -->
<!-- - [ ] authz-be -->
<!-- - [ ] authz-python -->
<!-- - [ ] python-flask-todo-list -->

### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] quickstart -->
<!-- - [ ] multi-tenancy -->
<!-- - [ ] data-plane/pulumi -->
<!-- - [ ] authz -->
<!-- - [ ] authz-be -->
<!-- - [ ] authz-python -->
<!-- - [ ] python-flask-todo-list -->
