### PR TITLE
fix(webapp): use better metrics names

### DIFF
--- a/webapp/components/InstanceMetrics/InstanceMetrics.tsx
+++ b/webapp/components/InstanceMetrics/InstanceMetrics.tsx
@@ -34,7 +34,6 @@ export default function InstanceMetrics() {
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const { properties } = instance ?? ({} as Record<string, any>);
-  console.log(properties, instanceName);
 
   return (
     <NavBar>

--- a/webapp/components/InstanceMetrics/hooks/index.ts
+++ b/webapp/components/InstanceMetrics/hooks/index.ts
@@ -15,6 +15,7 @@ export const useMetricsGenerator = (config: Config, cb?: () => void) => {
   const { metricName, intervalTimeMs, measurement } = config;
   const router = useRouter();
   const instanceId = String(router.query.instance);
+  const entity = String(router.query.entity);
 
   const _nile = useDeveloperNile();
 
@@ -24,7 +25,7 @@ export const useMetricsGenerator = (config: Config, cb?: () => void) => {
   const produceRequestMetrics = React.useCallback(async () => {
     const fakeMeasurement = measurement();
     const metricData = {
-      name: metricName,
+      name: `${metricName}-${entity ?? NILE_ENTITY_NAME}`,
       type: MetricTypeEnum.Gauge,
       entityType: NILE_ENTITY_NAME,
       measurements: [fakeMeasurement],
@@ -36,7 +37,15 @@ export const useMetricsGenerator = (config: Config, cb?: () => void) => {
       });
       cb && cb();
     }
-  }, [NILE_ENTITY_NAME, _nile, cb, instanceId, measurement, metricName]);
+  }, [
+    NILE_ENTITY_NAME,
+    _nile,
+    cb,
+    entity,
+    instanceId,
+    measurement,
+    metricName,
+  ]);
 
   const intervalFn = React.useCallback(() => {
     produceRequestMetrics();


### PR DESCRIPTION
### Description 
the names of the metrics are static, so you get some weird errors when you switch entities. This fixes that.

_What behavior does this PR change, and why?_

_Note any breaking changes_

### Checklist before merge

<!-- - [ ] Manually validate examples in prod -->
<!-- - [ ] Workflow in GitHub Actions passes -->
<!-- - [ ] Update relevant READMEs -->
<!-- - [ ] Spell check (e.g. using `aspell`) -->
<!-- - [ ] Ensure `Squash and merge` is checked -->
<!-- - [ ] Update GH workflow -->
<!-- - [ ] Update PR template -->

### Submitter Validation

_Describe the validation already done, or needs to be done, by the PR submitter._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] quickstart -->
<!-- - [ ] multi-tenancy -->
<!-- - [ ] data-plane/pulumi -->
<!-- - [ ] authz -->
<!-- - [ ] authz-be -->
<!-- - [ ] authz-python -->
<!-- - [ ] python-flask-todo-list -->

### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] quickstart -->
<!-- - [ ] multi-tenancy -->
<!-- - [ ] data-plane/pulumi -->
<!-- - [ ] authz -->
<!-- - [ ] authz-be -->
<!-- - [ ] authz-python -->
<!-- - [ ] python-flask-todo-list -->
